### PR TITLE
Report image name in `prepare` step

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -150,6 +150,7 @@ async fn prepare_step(context: &JobContext) -> anyhow::Result<()> {
         }
         GitLabExecutorPullPolicy::IfNotPresent => !image_exists,
     };
+    info!("Using image {}", image);
     if !pull_needed {
         info!("No pull necessary");
         return Ok(());


### PR DESCRIPTION
It's currently hard to see which image a job is running with.

Closes #18 